### PR TITLE
/hidden.html page added when shark Img is clicked

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,15 @@
+let zoomed = false;
+
+function toggleZoom() {
+  const image = document.getElementById('hiddenImage');
+  zoomed = !zoomed; 
+  if (zoomed) {
+    image.classList.add('zoomed');
+    image.classList.remove('hidden-page');
+    image.style.cursor = 'zoom-out';
+  } else {
+    image.classList.add('hidden-page');
+    image.classList.remove('zoomed');
+    image.style.cursor = 'zoom-in';
+  }
+}

--- a/hidden.html
+++ b/hidden.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="main.css">
+  <title>Hidden page</title>
+  <link rel="shortcut icon" type="image/jpeg" href="assets/shark.jpeg" >
+</head>
+<body class="hidden-body">
+  <img class="hidden-page" id="hiddenImage" src="https://courses.cs.washington.edu/courses/cse190m/12sp/labs/1/images/aboutme.png" alt="hidden page" onclick="toggleZoom()">
+</body>
+
+<script src="app.js"></script>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
  <!--First section-->
  <div class="first-section">
-  <img class="shark-img" src="assets/shark.jpeg" alt="shark">
+  <a href="hidden.html"><img class="shark-img" src="assets/shark.jpeg" alt="shark"></a>
   <h1 class="shark-title">Moisés the Shark</h1>
   <p class="first-paragraph"><em>The future programmer</em></p>
   <p class="second-paragraph"><a href="about.html">About this site</a></p>

--- a/main.css
+++ b/main.css
@@ -102,3 +102,32 @@ body {
   font-size: 20px;
   line-height: 2;
 }
+
+/* Hidden Page */
+.hidden-body{
+  background-color: rgb(14, 14, 14);
+  margin: 0;
+  height: 100%;
+}
+
+.hidden-page {
+  display: block;
+  margin: auto;
+  cursor: zoom-in;
+  background-color: hsl(0, 0%, 90%);
+  transition: background-color 300ms;
+  width: 738px;
+  aspect-ratio: auto 738 / 788;
+  height: 788px;
+  overflow-clip-margin: content-box;
+  overflow: clip;
+}
+
+.zoomed {
+  width: 992px;
+  height: 1058px;
+  aspect-ratio: auto 992 / 1058;
+  display: block;
+  margin: auto;
+}
+


### PR DESCRIPTION
A 'hidden.html' page has been created with JavaScript functionality to toggle between zooming in and zooming out, providing the same functionality as an image. In the attached screenshots, you can see this functionality. Any issue, please let me know, I appreciate your feedback.



<img width="1440" alt="Screenshot 2024-02-06 at 21 43 00" src="https://github.com/flaviostutz/onboarding-web-students/assets/117291517/02fbfb0d-132c-498e-a5c9-0d5546d05441">
![Screenshot 2024-02-06 at 21 43 00 (2)](https://github.com/flaviostutz/onboarding-web-students/assets/117291517/771c6701-86ac-4643-8545-a49cd7b32cea)

<img width="1440" alt="Screenshot 2024-02-06 at 21 43 19" src="https://github.com/flaviostutz/onboarding-web-students/assets/117291517/152cfb29-6178-4af6-b1fa-2d7dd924775d">
![Screenshot 2024-02-06 at 21 43 19 (2)](https://github.com/flaviostutz/onboarding-web-students/assets/117291517/eeab1d54-6d81-4c6b-b8c1-dd01fab1edf0)

